### PR TITLE
Fix/fail empty batch

### DIFF
--- a/src/evm/WormholeVerifier.sol
+++ b/src/evm/WormholeVerifier.sol
@@ -100,11 +100,12 @@ contract WormholeVerifier is EIP712Encoding {
   uint256 private constant SHIFT_GET_20 = 256 - 20 * 8;
 
   // Slot layout information
+  // NOTE: We break up the keyspace into 64 bit sub-spaces, to make the keyspace more manageable.
+  //       We list the index sizes for each sub-space. There's a lot of gaps in the keyspace,
+  //       this is just to keep the sub-spaces uniform.
   uint256 private constant SLOT_MULTISIG_KEY_COUNT  = 1000;
   uint256 private constant SLOT_SCHNORR_KEY_COUNT   = 1001;
 
-  // NOTE: The full 160 bit keyspace is broken into 64 bit sub-spaces, to make the keyspace more manageable.
-  //       The sizes of each sub-structure are two to the power of the number of bits listed
   uint256 private constant SLOT_MULTISIG_KEY_DATA       = 1 << 64; // 32 bit keyspace (32 bit key index)
   uint256 private constant SLOT_SCHNORR_KEY_DATA        = 2 << 64; // 32 bit keyspace (32 bit key index)
   uint256 private constant SLOT_SCHNORR_EXTRA_DATA      = 3 << 64; // 32 bit keyspace (32 bit key index)

--- a/src/evm/WormholeVerifier.sol
+++ b/src/evm/WormholeVerifier.sol
@@ -207,10 +207,9 @@ contract WormholeVerifier is EIP712Encoding {
   uint256 private constant LENGTH_BATCH_SCHNORR_UNIFORM_ENTRY  = 20 + 32 + 32;
 
   // Schnorr challenge information
-  uint256 private constant OFFSET_SCHNORR_CHALLENGE_PARITY = 32;
-  uint256 private constant OFFSET_SCHNORR_CHALLENGE_DIGEST = 32 + 1;
-  uint256 private constant OFFSET_SCHNORR_CHALLENGE_R      = 32 + 1 + 32;
-  uint256 private constant LENGTH_SCHNORR_CHALLENGE        = 32 + 1 + 32 + 20;
+  uint256 private constant OFFSET_SCHNORR_CHALLENGE_PUBKEY = 20;
+  uint256 private constant OFFSET_SCHNORR_CHALLENGE_DIGEST = 20 + 32;
+  uint256 private constant LENGTH_SCHNORR_CHALLENGE        = 20 + 32 + 32;
 
   // Ecrecover information
   address private constant ADDRESS_ECRECOVER = 0x0000000000000000000000000000000000000001;
@@ -345,9 +344,8 @@ contract WormholeVerifier is EIP712Encoding {
       }
 
       function computeSchnorrChallenge(px, parity, digest, r, buffer) -> e {
-        mstore(add(buffer, OFFSET_SCHNORR_CHALLENGE_R), shl(SHIFT_GET_20, r))
-        mstore(buffer, px)
-        mstore8(add(buffer, OFFSET_SCHNORR_CHALLENGE_PARITY), parity)
+        mstore(buffer, shl(SHIFT_GET_20, r))
+        mstore(add(buffer, OFFSET_SCHNORR_CHALLENGE_PUBKEY), or(shl(1, px), parity)) // TODO: We could save a few gas by passing in the raw pubkey directly
         mstore(add(buffer, OFFSET_SCHNORR_CHALLENGE_DIGEST), digest)
         e := keccak256(buffer, LENGTH_SCHNORR_CHALLENGE)
       }
@@ -610,10 +608,9 @@ contract WormholeVerifier is EIP712Encoding {
       }
 
       function computeSchnorrChallenge(px, parity, digest, r, buffer) -> e {
-        mstore(buffer, px)
-        mstore8(add(buffer, OFFSET_SCHNORR_CHALLENGE_PARITY), parity)
+        mstore(buffer, shl(SHIFT_GET_20, r))
+        mstore(add(buffer, OFFSET_SCHNORR_CHALLENGE_PUBKEY), or(shl(1, px), parity)) // TODO: We could save a few gas by passing in the raw pubkey directly
         mstore(add(buffer, OFFSET_SCHNORR_CHALLENGE_DIGEST), digest)
-        mstore(add(buffer, OFFSET_SCHNORR_CHALLENGE_R), shl(SHIFT_GET_20, r))
         e := keccak256(buffer, LENGTH_SCHNORR_CHALLENGE)
       }
 

--- a/src/evm/WormholeVerifier.sol
+++ b/src/evm/WormholeVerifier.sol
@@ -722,12 +722,12 @@ contract WormholeVerifier is EIP712Encoding {
 
         // Verify the signatures
         let newBuffer := add(buffer, keyDataSize)
-        let entryInvalidIndex, entryInvalidMismatch, entryInvalidUsedSigner := checkMultisigSignature(digest, signaturesOffset, signatureCount, buffer, keyCount, newBuffer)
+        invalidIndex, invalidMismatch, invalidUsedSigner := checkMultisigSignature(digest, signaturesOffset, signatureCount, buffer, keyCount, newBuffer)
 
         // Validate the header
         let quorum := div(shl(1, keyCount), 3) // TODO: magic number
-        let entryInvalidSignatureCount := iszero(gt(signatureCount, quorum))
-        let entryInvalidExpirationTime := iszero(or(iszero(expirationTime), gt(expirationTime, timestamp())))
+        invalidSignatureCount := iszero(gt(signatureCount, quorum))
+        invalidExpirationTime := iszero(or(iszero(expirationTime), gt(expirationTime, timestamp())))
       }
 
       function verifySingleSchnorr(keyIndex, r, s, digest, buffer) -> invalidExpirationTime, invalidPubkey, invalidSignature, invalidMismatch {
@@ -737,8 +737,8 @@ contract WormholeVerifier is EIP712Encoding {
         let expirationTime := decodeSchnorrExtraExpirationTime(extraData)
 
         // Verify the signature
-        let entryInvalidExpirationTime := iszero(or(iszero(expirationTime), gt(expirationTime, timestamp())))
-        let entryInvalidPubkey, entryInvalidSignature, entryInvalidMismatch := checkSchnorrSignature(px, parity, digest, r, s, buffer)
+        invalidExpirationTime := iszero(or(iszero(expirationTime), gt(expirationTime, timestamp())))
+        invalidPubkey, invalidSignature, invalidMismatch := checkSchnorrSignature(px, parity, digest, r, s, buffer)
       }
 
       function verifyBatch() {

--- a/src/evm/WormholeVerifier.sol
+++ b/src/evm/WormholeVerifier.sol
@@ -345,10 +345,10 @@ contract WormholeVerifier is EIP712Encoding {
       }
 
       function computeSchnorrChallenge(px, parity, digest, r, buffer) -> e {
+        mstore(add(buffer, OFFSET_SCHNORR_CHALLENGE_R), shl(SHIFT_GET_20, r))
         mstore(buffer, px)
         mstore8(add(buffer, OFFSET_SCHNORR_CHALLENGE_PARITY), parity)
         mstore(add(buffer, OFFSET_SCHNORR_CHALLENGE_DIGEST), digest)
-        mstore(add(buffer, OFFSET_SCHNORR_CHALLENGE_R), shl(SHIFT_GET_20, r))
         e := keccak256(buffer, LENGTH_SCHNORR_CHALLENGE)
       }
 

--- a/src/evm/WormholeVerifier.sol
+++ b/src/evm/WormholeVerifier.sol
@@ -1419,14 +1419,14 @@ contract WormholeVerifier is EIP712Encoding {
 
   function _storeSchnorrShardDataBlock(uint32 schnorrKeyIndex, bytes memory shardData) internal {
     uint256 shardCount = shardData.length >> 6;
-    for (uint i = 0; i < shardCount; ++i) {
+    for (uint8 i = 0; i < shardCount; ++i) {
       uint256 shardReadOffset = (i * 2 + 1) * LENGTH_WORD;
       uint256 idReadOffset = (i * 2 + 2) * LENGTH_WORD;
-      uint256 shardWriteOffset = SLOT_SCHNORR_SHARD_MAP_SHARD + i * LENGTH_WORD;
-      uint256 idWriteOffset = SLOT_SCHNORR_SHARD_MAP_ID + i * LENGTH_WORD;
+      uint256 shardWriteSlot = _slotShardMapShard(schnorrKeyIndex, i);
+      uint256 idWriteSlot = _slotShardMapId(schnorrKeyIndex, i);
       assembly ("memory-safe") {
-        sstore(shardWriteOffset, mload(add(shardData, shardReadOffset)))
-        sstore(idWriteOffset, mload(add(shardData, idReadOffset)))
+        sstore(shardWriteSlot, mload(add(shardData, shardReadOffset)))
+        sstore(idWriteSlot, mload(add(shardData, idReadOffset)))
       }
     }
   }

--- a/src/solana/programs/verification_v2/src/schnorr_key.rs
+++ b/src/solana/programs/verification_v2/src/schnorr_key.rs
@@ -61,10 +61,10 @@ impl SchnorrKey {
     let s = signature.s;
 
     let mut message_challenge = [0u8; 85];
-    message_challenge[0..32].copy_from_slice(&px.to_big_endian());
-    message_challenge[32] = parity as u8;
-    message_challenge[33..65].copy_from_slice(digest);
-    message_challenge[65..85].copy_from_slice(&r);
+    message_challenge[0..20].copy_from_slice(&r);
+    message_challenge[20..52].copy_from_slice(&px.to_big_endian());
+    message_challenge[52] = parity as u8;
+    message_challenge[53..85].copy_from_slice(digest);
 
     let e = U256::from_big_endian(&hash(&message_challenge).to_bytes());
 

--- a/src/solana/programs/verification_v2/src/schnorr_key.rs
+++ b/src/solana/programs/verification_v2/src/schnorr_key.rs
@@ -60,11 +60,10 @@ impl SchnorrKey {
     let r = signature.r;
     let s = signature.s;
 
-    let mut message_challenge = [0u8; 85];
+    let mut message_challenge = [0u8; 84];
     message_challenge[0..20].copy_from_slice(&r);
-    message_challenge[20..52].copy_from_slice(&px.to_big_endian());
-    message_challenge[52] = parity as u8;
-    message_challenge[53..85].copy_from_slice(digest);
+    message_challenge[20..52].copy_from_slice(&self.key.to_big_endian());
+    message_challenge[52..84].copy_from_slice(digest);
 
     let e = U256::from_big_endian(&hash(&message_challenge).to_bytes());
 

--- a/src/solana/tests/verification_v2.ts
+++ b/src/solana/tests/verification_v2.ts
@@ -49,34 +49,6 @@ export const createAppendSchnorrKeyMessage = ({
   shardDataHash: randomBytes(32),
 })
 
-// Signature for 100 zero bytes body VAA with `testSchnorrKey` hashed only once
-// ContractSig{
-//   pkX                : 0x1cafae803bf91a2e5494162625d34fda2f69db7c1f3589938647bc2abd4a0a0f
-//   pkyparity          : 0
-//   msghash            : 0x913fb9e1f6f1c6d910fd574a5cad8857aa43bfba24e401ada4f56090d4d997a7
-//   s                  : 0x1c2d1ca6fd3830e653d2abfc57956f3700059a661d8cabae684ea1bc62294e4c
-//   nonceTimesGAddress : 0xe46df5bea4597cef7d3c6eff36356a3f0ba33a56
-// }
-
-// const testSchnorrKey = encoding.bignum.toBytes(
-//   0x1cafae803bf91a2e5494162625d34fda2f69db7c1f3589938647bc2abd4a0a0fn << 1n, 32
-// );
-
-// const signatureTestMessage100Zeroed = {
-//   r: encoding.hex.decode("0xE46Df5BEa4597CEF7D3c6EfF36356A3F0bA33a56"),
-//   s: encoding.hex.decode("0x1c2d1ca6fd3830e653d2abfc57956f3700059a661d8cabae684ea1bc62294e4c"),
-// }
-
-
-// Signature for 100 zero bytes body VAA with `testSchnorrKey` hashed twice
-// ContractSig{
-//   pkX                : 0x79380e24c7cbb0f88706dd035135020063aab3e7f403398ff7f995af0b8a770c
-//   pkyparity          : 0
-//   msghash            : 0x258752639c534fd7fb6b52e5e3ba32ed9e8de081c966fd895992f63464869309
-//   s                  : 0xaa6d485b7d7b536442ea7777127d35af43ac539a491c0d85ee0f635eb7745b29
-//   nonceTimesGAddress : 0x636a8688ef4b82e5a121f7c74d821a5b07d695f3
-// }
-
 const testSchnorrKey = encoding.bignum.toBytes(
   0xc11b6c8b8e4ecc62ebf10437678eb70f17f1e53abdb3fa8df1912e3b3d11b5b9n, 32
 );

--- a/src/solana/tests/verification_v2.ts
+++ b/src/solana/tests/verification_v2.ts
@@ -78,7 +78,7 @@ export const createAppendSchnorrKeyMessage = ({
 // }
 
 const testSchnorrKey = encoding.bignum.toBytes(
-  0xc11b6c8b8e4ecc62ebf10437678eb70f17f1e53abdb3fa8df1912e3b3d11b5b9cn, 32
+  0xc11b6c8b8e4ecc62ebf10437678eb70f17f1e53abdb3fa8df1912e3b3d11b5b9n, 32
 );
 
 const signatureTestMessage100Zeroed = {

--- a/src/solana/tests/verification_v2.ts
+++ b/src/solana/tests/verification_v2.ts
@@ -78,12 +78,12 @@ export const createAppendSchnorrKeyMessage = ({
 // }
 
 const testSchnorrKey = encoding.bignum.toBytes(
-  0x79380e24c7cbb0f88706dd035135020063aab3e7f403398ff7f995af0b8a770cn << 1n, 32
+  0xc11b6c8b8e4ecc62ebf10437678eb70f17f1e53abdb3fa8df1912e3b3d11b5b9cn, 32
 );
 
 const signatureTestMessage100Zeroed = {
-  r: encoding.hex.decode("0x636a8688ef4b82e5a121f7c74d821a5b07d695f3"),
-  s: encoding.hex.decode("0xaa6d485b7d7b536442ea7777127d35af43ac539a491c0d85ee0f635eb7745b29"),
+  r: encoding.hex.decode("0x41CF8d30EBCc800b655eAD15cC96014d36c4246B"),
+  s: encoding.hex.decode("0xfb5fa64887c4a05818b02afa7483e5115f19a93739c4b9ce4e92bae191a2ef4b"),
 }
 
 const invalidSignature = {

--- a/test/TestAssembly2.sol
+++ b/test/TestAssembly2.sol
@@ -477,9 +477,9 @@ contract TestAssembly2Benchmark is VerificationTestAPI {
     bytes memory bigMultisigSignatures = signMultisig(bigEnvelope, guardianPrivateKeysSlice);
     bigMultisigVaa = newMultisigVaa(0, bigMultisigSignatures, bigEnvelope);
 
-    uint256 pk2 = 0x44c90dfbe2a454987a65ce9e6f522c9c5c9d1dfb3c3aaaadcd0ae4f5366a2922 << 1;
-    address r2 = 0xD970AcFC9e8ff8BE38b0Fd6C4Fe4DD4DDB744cb4;
-    uint256 s2 = 0xfc201908d0a3aec1973711f48365deaa91180ef2771cb3744bccfc3ba77d6c77;
+    uint256 pk2 = 0xf779a04be48acabfbe8cb12e3c490139390615475a6207c1ff05494bcc5e57e9;
+    address r2 = 0x3B471F00A5557F3D8da3192ef7A5E07cE8be2b12;
+    uint256 s2 = 0x5908af479f7575f6880fa41e899353135420f60ccb3ceda366bb27f3b606963a;
     bigSchnorrVaa = newSchnorrVaa(1, r2, s2, bigEnvelope);
 
     schnorrPublicKeys = new uint256[](2);
@@ -844,9 +844,9 @@ contract TestAssembly2 is VerificationTestAPI {
     bytes memory bigMultisigSignatures = signMultisig(bigEnvelope, guardianPrivateKeysSlice);
     bigMultisigVaa = newMultisigVaa(0, bigMultisigSignatures, bigEnvelope);
 
-    uint256 pk2 = 0x44c90dfbe2a454987a65ce9e6f522c9c5c9d1dfb3c3aaaadcd0ae4f5366a2922 << 1;
-    address r2 = 0xD970AcFC9e8ff8BE38b0Fd6C4Fe4DD4DDB744cb4;
-    uint256 s2 = 0xfc201908d0a3aec1973711f48365deaa91180ef2771cb3744bccfc3ba77d6c77;
+    uint256 pk2 = 0xf779a04be48acabfbe8cb12e3c490139390615475a6207c1ff05494bcc5e57e9;
+    address r2 = 0x3B471F00A5557F3D8da3192ef7A5E07cE8be2b12;
+    uint256 s2 = 0x5908af479f7575f6880fa41e899353135420f60ccb3ceda366bb27f3b606963a;
     bigSchnorrVaa = newSchnorrVaa(1, r2, s2, bigEnvelope);
 
     invalidMultisigVaa = new bytes(100);

--- a/test/TestAssembly2.sol
+++ b/test/TestAssembly2.sol
@@ -53,7 +53,16 @@ import {
   GET_SCHNORR_SHARD_DATA
 } from "../src/evm/WormholeVerifier.sol";
 
+// Test data for schnorr keys/signatures
+uint256 constant PK1 = 0xc11b6c8b8e4ecc62ebf10437678eb70f17f1e53abdb3fa8df1912e3b3d11b5b9;
+address constant R1 = 0x41CF8d30EBCc800b655eAD15cC96014d36c4246B;
+uint256 constant S1 = 0xfb5fa64887c4a05818b02afa7483e5115f19a93739c4b9ce4e92bae191a2ef4b;
 
+uint256 constant PK2 = 0x55c79afbfe1347cd62a6af7cfb28c20d4cc83f64e258a3140928518b96b004fc;
+address constant R2 = 0xFcAB39377D2520DcC524Bc7C511F8C1cCAFf0F63;
+uint256 constant S2 = 0x02c8055d150c27f4af49cea577ac20afba682ed4eb60977f305d5b1b1c1a75cd;
+
+// Generic constants and structs
 uint256 constant LENGTH_WORD = 0x20;
 
 struct ShardData {
@@ -469,22 +478,16 @@ contract TestAssembly2Benchmark is VerificationTestAPI {
     bytes memory smallMultisigSignatures = signMultisig(smallEnvelope, guardianPrivateKeysSlice);
     smallMultisigVaa = newMultisigVaa(0, smallMultisigSignatures, smallEnvelope);
 
-    uint256 pk1 = 0x79380e24c7cbb0f88706dd035135020063aab3e7f403398ff7f995af0b8a770c << 1;
-    address r1 = address(0x636a8688ef4B82E5A121F7C74D821A5b07d695f3);
-    uint256 s1 = 0xaa6d485b7d7b536442ea7777127d35af43ac539a491c0d85ee0f635eb7745b29;
-    smallSchnorrVaa = newSchnorrVaa(0, r1, s1, smallEnvelope);
+    smallSchnorrVaa = newSchnorrVaa(0, R1, S1, smallEnvelope);
 
     bytes memory bigMultisigSignatures = signMultisig(bigEnvelope, guardianPrivateKeysSlice);
     bigMultisigVaa = newMultisigVaa(0, bigMultisigSignatures, bigEnvelope);
 
-    uint256 pk2 = 0xf779a04be48acabfbe8cb12e3c490139390615475a6207c1ff05494bcc5e57e9;
-    address r2 = 0x3B471F00A5557F3D8da3192ef7A5E07cE8be2b12;
-    uint256 s2 = 0x5908af479f7575f6880fa41e899353135420f60ccb3ceda366bb27f3b606963a;
-    bigSchnorrVaa = newSchnorrVaa(1, r2, s2, bigEnvelope);
+    bigSchnorrVaa = newSchnorrVaa(1, R2, S2, bigEnvelope);
 
     schnorrPublicKeys = new uint256[](2);
-    schnorrPublicKeys[0] = pk1;
-    schnorrPublicKeys[1] = pk2;
+    schnorrPublicKeys[0] = PK1;
+    schnorrPublicKeys[1] = PK2;
 
     invalidVersionVaa = new bytes(100);
 
@@ -835,19 +838,13 @@ contract TestAssembly2 is VerificationTestAPI {
     bytes memory smallMultisigSignatures = signMultisig(smallEnvelope, guardianPrivateKeysSlice);
     smallMultisigVaa = newMultisigVaa(0, smallMultisigSignatures, smallEnvelope);
 
-    uint256 pk1 = 0x79380e24c7cbb0f88706dd035135020063aab3e7f403398ff7f995af0b8a770c << 1;
-    address r1 = address(0x636a8688ef4B82E5A121F7C74D821A5b07d695f3);
-    uint256 s1 = 0xaa6d485b7d7b536442ea7777127d35af43ac539a491c0d85ee0f635eb7745b29;
-    smallSchnorrVaa = newSchnorrVaa(0, r1, s1, smallEnvelope);
+    smallSchnorrVaa = newSchnorrVaa(0, R1, S1, smallEnvelope);
 
     bytes memory bigEnvelope = new bytes(5000);
     bytes memory bigMultisigSignatures = signMultisig(bigEnvelope, guardianPrivateKeysSlice);
     bigMultisigVaa = newMultisigVaa(0, bigMultisigSignatures, bigEnvelope);
 
-    uint256 pk2 = 0xf779a04be48acabfbe8cb12e3c490139390615475a6207c1ff05494bcc5e57e9;
-    address r2 = 0x3B471F00A5557F3D8da3192ef7A5E07cE8be2b12;
-    uint256 s2 = 0x5908af479f7575f6880fa41e899353135420f60ccb3ceda366bb27f3b606963a;
-    bigSchnorrVaa = newSchnorrVaa(1, r2, s2, bigEnvelope);
+    bigSchnorrVaa = newSchnorrVaa(1, R2, S2, bigEnvelope);
 
     invalidMultisigVaa = new bytes(100);
     invalidMultisigVaa[0] = 0x01;
@@ -868,11 +865,11 @@ contract TestAssembly2 is VerificationTestAPI {
     require(schnorrShardsRaw.length == SHARD_COUNT*64);
 
     bytes32 schnorrShardDataHash = keccak256(schnorrShardsRaw);
-    bytes memory appendSchnorrKeyMessage1 = newAppendSchnorrKeyMessage(0, 0, pk1, 0, schnorrShardDataHash);
+    bytes memory appendSchnorrKeyMessage1 = newAppendSchnorrKeyMessage(0, 0, PK1, 0, schnorrShardDataHash);
     bytes memory appendSchnorrKeyEnvelope1 = newVaaEnvelope(uint32(block.timestamp), 0, CHAIN_ID_SOLANA, GOVERNANCE_ADDRESS, 0, 0, appendSchnorrKeyMessage1);
     appendSchnorrKeyVaa1 = newMultisigVaa(0, signMultisig(appendSchnorrKeyEnvelope1, guardianPrivateKeysSet0), appendSchnorrKeyEnvelope1);
 
-    bytes memory appendSchnorrKeyMessage2 = newAppendSchnorrKeyMessage(1, 0, pk2, EXPIRATION_DELAY_SECONDS, schnorrShardDataHash);
+    bytes memory appendSchnorrKeyMessage2 = newAppendSchnorrKeyMessage(1, 0, PK2, EXPIRATION_DELAY_SECONDS, schnorrShardDataHash);
     bytes memory appendSchnorrKeyEnvelope2 = newVaaEnvelope(uint32(block.timestamp), 0, CHAIN_ID_SOLANA, GOVERNANCE_ADDRESS, 0, 0, appendSchnorrKeyMessage2);
     appendSchnorrKeyVaa2 = newMultisigVaa(0, signMultisig(appendSchnorrKeyEnvelope2, guardianPrivateKeysSet0), appendSchnorrKeyEnvelope2);
   }
@@ -1046,16 +1043,15 @@ contract TestAssembly2 is VerificationTestAPI {
   function test_appendMultipleSchnorrKey() public {
     pullGuardianSets(_wormholeVerifierV2, 1);
 
-    uint256 pk1 = 0x79380e24c7cbb0f88706dd035135020063aab3e7f403398ff7f995af0b8a770c << 1;
     bytes32 schnorrShardDataHash = keccak256(schnorrShardsRaw);
 
     uint32 schnorrKeyIndex = 2;
-    bytes memory appendSchnorrKeyMessage3 = newAppendSchnorrKeyMessage(schnorrKeyIndex, 0, pk1, 0, schnorrShardDataHash);
+    bytes memory appendSchnorrKeyMessage3 = newAppendSchnorrKeyMessage(schnorrKeyIndex, 0, PK1, 0, schnorrShardDataHash);
     bytes memory appendSchnorrKeyEnvelope3 = newVaaEnvelope(uint32(block.timestamp), 0, CHAIN_ID_SOLANA, GOVERNANCE_ADDRESS, 0, 0, appendSchnorrKeyMessage3);
     bytes memory appendSchnorrKeyVaa3 = newMultisigVaa(0, signMultisig(appendSchnorrKeyEnvelope3, guardianPrivateKeysSet0), appendSchnorrKeyEnvelope3);
 
     uint32 schnorrKeyIndex2 = 3;
-    bytes memory appendSchnorrKeyMessage4 = newAppendSchnorrKeyMessage(schnorrKeyIndex2, 0, pk1, 0, schnorrShardDataHash);
+    bytes memory appendSchnorrKeyMessage4 = newAppendSchnorrKeyMessage(schnorrKeyIndex2, 0, PK1, 0, schnorrShardDataHash);
     bytes memory appendSchnorrKeyEnvelope4 = newVaaEnvelope(uint32(block.timestamp), 0, CHAIN_ID_SOLANA, GOVERNANCE_ADDRESS, 0, 0, appendSchnorrKeyMessage4);
     bytes memory appendSchnorrKeyVaa4 = newMultisigVaa(0, signMultisig(appendSchnorrKeyEnvelope4, guardianPrivateKeysSet0), appendSchnorrKeyEnvelope4);
 
@@ -1069,10 +1065,9 @@ contract TestAssembly2 is VerificationTestAPI {
     uint32 schnorrKeyIndex2 = 3;
     WormholeVerifier tempVerifier = new WormholeVerifier(_wormholeV1Mock, 0, schnorrKeyIndex2, 1, new bytes(0));
 
-    uint256 pk1 = 0x79380e24c7cbb0f88706dd035135020063aab3e7f403398ff7f995af0b8a770c << 1;
     bytes32 schnorrShardDataHash = keccak256(schnorrShardsRaw);
 
-    bytes memory appendSchnorrKeyMessage4 = newAppendSchnorrKeyMessage(schnorrKeyIndex2, 0, pk1, 0, schnorrShardDataHash);
+    bytes memory appendSchnorrKeyMessage4 = newAppendSchnorrKeyMessage(schnorrKeyIndex2, 0, PK1, 0, schnorrShardDataHash);
     bytes memory appendSchnorrKeyEnvelope4 = newVaaEnvelope(uint32(block.timestamp), 0, CHAIN_ID_SOLANA, GOVERNANCE_ADDRESS, 0, 0, appendSchnorrKeyMessage4);
     bytes memory appendSchnorrKeyVaa4 = newMultisigVaa(0, signMultisig(appendSchnorrKeyEnvelope4, guardianPrivateKeysSet0), appendSchnorrKeyEnvelope4);
 
@@ -1112,11 +1107,10 @@ contract TestAssembly2 is VerificationTestAPI {
   function testRevert_appendOldSchnorrKey() public {
     pullGuardianSets(_wormholeVerifierV2, 1);
 
-    uint256 pk1 = 0x79380e24c7cbb0f88706dd035135020063aab3e7f403398ff7f995af0b8a770c << 1;
     bytes32 schnorrShardDataHash = keccak256(schnorrShardsRaw);
 
     uint32 schnorrKeyIndex = 0;
-    bytes memory appendSchnorrKeyMessage3 = newAppendSchnorrKeyMessage(schnorrKeyIndex, 0, pk1, 0, schnorrShardDataHash);
+    bytes memory appendSchnorrKeyMessage3 = newAppendSchnorrKeyMessage(schnorrKeyIndex, 0, PK1, 0, schnorrShardDataHash);
     bytes memory appendSchnorrKeyEnvelope3 = newVaaEnvelope(uint32(block.timestamp), 0, CHAIN_ID_SOLANA, GOVERNANCE_ADDRESS, 0, 0, appendSchnorrKeyMessage3);
     bytes memory appendSchnorrKeyVaa3 = newMultisigVaa(0, signMultisig(appendSchnorrKeyEnvelope3, guardianPrivateKeysSet0), appendSchnorrKeyEnvelope3);
 
@@ -1134,10 +1128,9 @@ contract TestAssembly2 is VerificationTestAPI {
     uint32 schnorrKeyIndex = type(uint32).max;
     WormholeVerifier tempVerifier = new WormholeVerifier(_wormholeV1Mock, 0, schnorrKeyIndex, 1, new bytes(0));
 
-    uint256 pk1 = 0x79380e24c7cbb0f88706dd035135020063aab3e7f403398ff7f995af0b8a770c << 1;
     bytes32 schnorrShardDataHash = keccak256(schnorrShardsRaw);
 
-    bytes memory appendSchnorrKeyMessage3 = newAppendSchnorrKeyMessage(schnorrKeyIndex, 0, pk1, 0, schnorrShardDataHash);
+    bytes memory appendSchnorrKeyMessage3 = newAppendSchnorrKeyMessage(schnorrKeyIndex, 0, PK1, 0, schnorrShardDataHash);
     bytes memory appendSchnorrKeyEnvelope3 = newVaaEnvelope(uint32(block.timestamp), 0, CHAIN_ID_SOLANA, GOVERNANCE_ADDRESS, 0, 0, appendSchnorrKeyMessage3);
     bytes memory appendSchnorrKeyVaa3 = newMultisigVaa(0, signMultisig(appendSchnorrKeyEnvelope3, guardianPrivateKeysSet0), appendSchnorrKeyEnvelope3);
 
@@ -1153,8 +1146,6 @@ contract TestAssembly2 is VerificationTestAPI {
     appendSchnorrKey(_wormholeVerifierV2, appendSchnorrKeyVaa1, schnorrShardsRaw);
     appendSchnorrKey(_wormholeVerifierV2, appendSchnorrKeyVaa2, schnorrShardsRaw);
 
-    uint256 pk2 = 0x44c90dfbe2a454987a65ce9e6f522c9c5c9d1dfb3c3aaaadcd0ae4f5366a2922 << 1;
-
     bytes memory result = _wormholeVerifierV2.get(getCurrentSchnorrKey());
 
     (
@@ -1164,8 +1155,9 @@ contract TestAssembly2 is VerificationTestAPI {
       uint8 shardCount,
       uint32 guardianSet,
     ) = decodeGetCurrentSchnorrKey(result, 0);
+
     assertEq(schnorrKeyIndex, 1);
-    assertEq(schnorrKeyPubkey, pk2);
+    assertEq(schnorrKeyPubkey, PK2);
     assertEq(expirationTime, 0);
     assertEq(shardCount, SHARD_COUNT);
     assertEq(guardianSet, 0);
@@ -1201,8 +1193,6 @@ contract TestAssembly2 is VerificationTestAPI {
     appendSchnorrKey(_wormholeVerifierV2, appendSchnorrKeyVaa1, schnorrShardsRaw);
     appendSchnorrKey(_wormholeVerifierV2, appendSchnorrKeyVaa2, schnorrShardsRaw);
 
-    uint256 pk1 = 0x79380e24c7cbb0f88706dd035135020063aab3e7f403398ff7f995af0b8a770c << 1;
-
     bytes memory result = _wormholeVerifierV2.get(getSchnorrKey(0));
 
     (
@@ -1211,7 +1201,8 @@ contract TestAssembly2 is VerificationTestAPI {
       uint8 shardCount,
       uint32 guardianSet,
     ) = decodeGetSchnorrKey(result, 0);
-    assertEq(schnorrKeyPubkey, pk1);
+
+    assertEq(schnorrKeyPubkey, PK1);
     assertEq(expirationTime, expirationTimeSet0);
     assertEq(shardCount, SHARD_COUNT);
     assertEq(guardianSet, 0);

--- a/test/TestAssembly2.sol
+++ b/test/TestAssembly2.sol
@@ -777,18 +777,45 @@ contract TestAssembly2Benchmark is VerificationTestAPI {
   }
 
   function test_verifyBatchEmpty() public {
-    (bool success, bytes memory data) = address(_wormholeVerifierV2).call(abi.encodePacked(
-      WormholeVerifier.verifyBatch.selector,
-      VERIFY_MULTISIG_UNIFORM,
-      uint32(0) // Key index
-    ));
-    vm.assertEq(success, false);
-
+    bool success;
+    bytes memory data;
+    
     (success, data) = address(_wormholeVerifierV2).call(abi.encodePacked(
       WormholeVerifier.verifyBatch.selector,
       VERIFY_ANY
     ));
     vm.assertEq(success, false);
+    vm.assertEq(data.length, 4+32);
+
+    (success, data) = address(_wormholeVerifierV2).call(abi.encodePacked(
+      WormholeVerifier.verifyBatch.selector,
+      VERIFY_SCHNORR
+    ));
+    vm.assertEq(success, false);
+    vm.assertEq(data.length, 4+32);
+
+    (success, data) = address(_wormholeVerifierV2).call(abi.encodePacked(
+      WormholeVerifier.verifyBatch.selector,
+      VERIFY_MULTISIG
+    ));
+    vm.assertEq(success, false);
+    vm.assertEq(data.length, 4+32);
+
+    (success, data) = address(_wormholeVerifierV2).call(abi.encodePacked(
+      WormholeVerifier.verifyBatch.selector,
+      VERIFY_SCHNORR_UNIFORM,
+      uint32(0) // Key index
+    ));
+    vm.assertEq(success, false);
+    vm.assertEq(data.length, 4+32);
+
+    (success, data) = address(_wormholeVerifierV2).call(abi.encodePacked(
+      WormholeVerifier.verifyBatch.selector,
+      VERIFY_MULTISIG_UNIFORM,
+      uint32(0) // Key index
+    ));
+    vm.assertEq(success, false);
+    vm.assertEq(data.length, 4+32);
   }
 }
 

--- a/test/TestAssembly2.sol
+++ b/test/TestAssembly2.sol
@@ -383,6 +383,7 @@ contract WormholeV1MockVerification {
       signatures: new GuardianSignature[](0),
       hash: 0x0
     });
+
     return (result, true, "");
   }
 }
@@ -508,8 +509,8 @@ contract TestAssembly2Benchmark is VerificationTestAPI {
     bytes memory bigSchnorrVaaHeader2 = new bytes(schnorrVaaHeaderLength2);
 
     for (uint256 i = 0; i < schnorrVaaHeaderLength2; i++) {
-      smallSchnorrVaaHeader2[i] = smallSchnorrVaa[i];
-      bigSchnorrVaaHeader2[i] = bigSchnorrVaa[i];
+      smallSchnorrVaaHeader2[i] = smallSchnorrVaa[i + 1];
+      bigSchnorrVaaHeader2[i] = bigSchnorrVaa[i + 1];
     }
 
     batchMultisigMessage = abi.encodePacked(
@@ -1232,4 +1233,3 @@ contract TestAssembly2 is VerificationTestAPI {
     _wormholeVerifierV2.verify(smallSchnorrVaa);
   }
 }
-

--- a/test/TestAssembly2.sol
+++ b/test/TestAssembly2.sol
@@ -775,6 +775,21 @@ contract TestAssembly2Benchmark is VerificationTestAPI {
     vm.assertEq(success, false);
     vm.assertEq(data.length, 4+32);
   }
+
+  function test_verifyBatchEmpty() public {
+    (bool success, bytes memory data) = address(_wormholeVerifierV2).call(abi.encodePacked(
+      WormholeVerifier.verifyBatch.selector,
+      VERIFY_MULTISIG_UNIFORM,
+      uint32(0) // Key index
+    ));
+    vm.assertEq(success, false);
+
+    (success, data) = address(_wormholeVerifierV2).call(abi.encodePacked(
+      WormholeVerifier.verifyBatch.selector,
+      VERIFY_ANY
+    ));
+    vm.assertEq(success, false);
+  }
 }
 
 contract TestAssembly2 is VerificationTestAPI {


### PR DESCRIPTION
Added a check for zero-sized batch in all batch verification cases to give proper error handling.
Added test to verify the corresponding calls fail.